### PR TITLE
Adjust and export interfaces 

### DIFF
--- a/src/Breadcrumbs/BreadcrumbEllipsis/index.tsx
+++ b/src/Breadcrumbs/BreadcrumbEllipsis/index.tsx
@@ -5,7 +5,7 @@ import { BreadcrumbMenu } from "../BreadcrumbMenu";
 
 import { IBreadcrumbsRoutes } from "../props";
 
-import { Size } from "./props";
+import { IBreadcrumbEllipsisSize } from "./props";
 import {
   StyledContainerEllipsis,
   StyledBreadcrumbEllipsis,
@@ -13,7 +13,7 @@ import {
 } from "./styles";
 
 interface IBreadcrumbEllipsis extends IBreadcrumbsRoutes {
-  size?: Size;
+  size?: IBreadcrumbEllipsisSize;
 }
 
 const BreadcrumbEllipsis = (props: IBreadcrumbEllipsis) => {

--- a/src/Breadcrumbs/BreadcrumbEllipsis/props.ts
+++ b/src/Breadcrumbs/BreadcrumbEllipsis/props.ts
@@ -1,5 +1,5 @@
 const sizes = ["large", "small"] as const;
-type Size = (typeof sizes)[number];
+type IBreadcrumbEllipsisSize = (typeof sizes)[number];
 
 const props = {
   parameters: {
@@ -35,4 +35,4 @@ const props = {
 };
 
 export { props, sizes };
-export type { Size };
+export type { IBreadcrumbEllipsisSize };

--- a/src/Breadcrumbs/BreadcrumbLink/index.tsx
+++ b/src/Breadcrumbs/BreadcrumbLink/index.tsx
@@ -1,13 +1,13 @@
 import { Text } from "@inubekit/text";
 import { inube } from "@inubekit/foundations";
-import { Sizes } from "./props";
+import { IBreadcrumbLinkSizes } from "./props";
 import { StyledContainerLink, StyledBreadcrumbLink } from "./styles";
 
 interface IBreadcrumbLink {
   label: string;
   path: string;
   id: string;
-  size?: Sizes;
+  size?: IBreadcrumbLinkSizes;
   active?: boolean;
   onClick?: (e: React.MouseEvent) => void;
 }

--- a/src/Breadcrumbs/BreadcrumbLink/index.tsx
+++ b/src/Breadcrumbs/BreadcrumbLink/index.tsx
@@ -1,13 +1,13 @@
 import { Text } from "@inubekit/text";
 import { inube } from "@inubekit/foundations";
-import { IBreadcrumbLinkSizes } from "./props";
+import { IBreadcrumbLinkSize } from "./props";
 import { StyledContainerLink, StyledBreadcrumbLink } from "./styles";
 
 interface IBreadcrumbLink {
   label: string;
   path: string;
   id: string;
-  size?: IBreadcrumbLinkSizes;
+  size?: IBreadcrumbLinkSize;
   active?: boolean;
   onClick?: (e: React.MouseEvent) => void;
 }

--- a/src/Breadcrumbs/BreadcrumbLink/props.ts
+++ b/src/Breadcrumbs/BreadcrumbLink/props.ts
@@ -1,4 +1,4 @@
-type Sizes = "large" | "small";
+type IBreadcrumbLinkSizes = "large" | "small";
 
 const parameters = {
   docs: {
@@ -35,4 +35,4 @@ const props = {
 };
 
 export { parameters, props };
-export type { Sizes };
+export type { IBreadcrumbLinkSizes };

--- a/src/Breadcrumbs/BreadcrumbLink/props.ts
+++ b/src/Breadcrumbs/BreadcrumbLink/props.ts
@@ -1,4 +1,6 @@
-type IBreadcrumbLinkSizes = "large" | "small";
+import { sizes } from "../props";
+
+type IBreadcrumbLinkSize = (typeof sizes)[number];
 
 const parameters = {
   docs: {
@@ -35,4 +37,4 @@ const props = {
 };
 
 export { parameters, props };
-export type { IBreadcrumbLinkSizes };
+export type { IBreadcrumbLinkSize };

--- a/src/Breadcrumbs/BreadcrumbMenuLink/index.tsx
+++ b/src/Breadcrumbs/BreadcrumbMenuLink/index.tsx
@@ -1,9 +1,9 @@
 import { Text } from "@inubekit/text";
 
-import { IRoute } from "../props";
+import { IBreadcrumbsRoute } from "../props";
 import { StyledContainerLink, StyledBreadcrumbMenuLink } from "./styles";
 
-const BreadcrumbMenuLink = (props: IRoute) => {
+const BreadcrumbMenuLink = (props: IBreadcrumbsRoute) => {
   const { label, path, id, size = "large" } = props;
 
   return (

--- a/src/Breadcrumbs/BreadcrumbMenuLink/stories/BreadcrumbMenuLink.stories.tsx
+++ b/src/Breadcrumbs/BreadcrumbMenuLink/stories/BreadcrumbMenuLink.stories.tsx
@@ -1,6 +1,6 @@
 import { BrowserRouter } from "react-router-dom";
 
-import { IRoute } from "../../props";
+import { IBreadcrumbsRoute } from "../../props";
 import { props } from "../props";
 import { BreadcrumbMenuLink } from "..";
 
@@ -17,7 +17,7 @@ const story = {
   ],
 };
 
-const Default = (args: IRoute) => <BreadcrumbMenuLink {...args} />;
+const Default = (args: IBreadcrumbsRoute) => <BreadcrumbMenuLink {...args} />;
 Default.args = {
   label: "Privileges",
   path: "/privileges",

--- a/src/Breadcrumbs/index.tsx
+++ b/src/Breadcrumbs/index.tsx
@@ -2,11 +2,11 @@ import { useMediaQuery } from "@inubekit/hooks";
 
 import { BreadcrumbLink } from "./BreadcrumbLink";
 import { BreadcrumbEllipsis } from "./BreadcrumbEllipsis";
-import { IRoute } from "./props";
+import { IBreadcrumbsIRoute } from "./props";
 import { StyledBreadcrumbs } from "./styles";
 
 interface IBreadcrumbs {
-  crumbs: IRoute[];
+  crumbs: IBreadcrumbsIRoute[];
 }
 
 function capitalizeString(string: string) {

--- a/src/Breadcrumbs/index.tsx
+++ b/src/Breadcrumbs/index.tsx
@@ -2,11 +2,11 @@ import { useMediaQuery } from "@inubekit/hooks";
 
 import { BreadcrumbLink } from "./BreadcrumbLink";
 import { BreadcrumbEllipsis } from "./BreadcrumbEllipsis";
-import { IBreadcrumbsIRoute } from "./props";
+import { IBreadcrumbsRoute } from "./props";
 import { StyledBreadcrumbs } from "./styles";
 
 interface IBreadcrumbs {
-  crumbs: IBreadcrumbsIRoute[];
+  crumbs: IBreadcrumbsRoute[];
 }
 
 function capitalizeString(string: string) {

--- a/src/Breadcrumbs/props.ts
+++ b/src/Breadcrumbs/props.ts
@@ -1,16 +1,16 @@
 const sizes = ["large", "small"] as const;
-type Sizes = (typeof sizes)[number];
+type IBreadcrumbsSizes = (typeof sizes)[number];
 
-interface IRoute {
+interface IBreadcrumbsIRoute {
   path: string;
   label: string;
   id: string;
   isActive?: boolean;
-  size?: Sizes;
+  size?: IBreadcrumbsSizes;
 }
 
 interface IBreadcrumbsRoutes {
-  routes: IRoute[];
+  routes: IBreadcrumbsIRoute[];
 }
 
 const props = {
@@ -29,4 +29,4 @@ const props = {
 };
 
 export { props, sizes };
-export type { IBreadcrumbsRoutes, IRoute, Sizes };
+export type { IBreadcrumbsRoutes, IBreadcrumbsIRoute, IBreadcrumbsSizes };

--- a/src/Breadcrumbs/props.ts
+++ b/src/Breadcrumbs/props.ts
@@ -1,16 +1,16 @@
 const sizes = ["large", "small"] as const;
-type IBreadcrumbsSizes = (typeof sizes)[number];
+type IBreadcrumbsSize = (typeof sizes)[number];
 
-interface IBreadcrumbsIRoute {
+interface IBreadcrumbsRoute {
   path: string;
   label: string;
   id: string;
   isActive?: boolean;
-  size?: IBreadcrumbsSizes;
+  size?: IBreadcrumbsSize;
 }
 
 interface IBreadcrumbsRoutes {
-  routes: IBreadcrumbsIRoute[];
+  routes: IBreadcrumbsRoute[];
 }
 
 const props = {
@@ -29,4 +29,4 @@ const props = {
 };
 
 export { props, sizes };
-export type { IBreadcrumbsRoutes, IBreadcrumbsIRoute, IBreadcrumbsSizes };
+export type { IBreadcrumbsRoutes, IBreadcrumbsRoute, IBreadcrumbsSize };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,13 @@
 export { Breadcrumbs } from "./Breadcrumbs";
+
+export type { IBreadcrumbEllipsis } from "./Breadcrumbs/BreadcrumbEllipsis";
+export type { IBreadcrumbEllipsisSize } from "./Breadcrumbs/BreadcrumbEllipsis/props";
+export type { IBreadcrumbLink } from "./Breadcrumbs/BreadcrumbLink";
+export type { IBreadcrumbLinkSizes } from "./Breadcrumbs/BreadcrumbLink/props";
+export type { IBreadcrumbs } from "./Breadcrumbs/index";
+export type {
+  IBreadcrumbsRoutes,
+  IBreadcrumbsIRoute,
+  IBreadcrumbsSizes,
+} from "./Breadcrumbs/props";
+export type { IBreadcrumbMenu } from "./Breadcrumbs/BreadcrumbMenu";

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,10 @@ export { Breadcrumbs } from "./Breadcrumbs";
 export type { IBreadcrumbEllipsis } from "./Breadcrumbs/BreadcrumbEllipsis";
 export type { IBreadcrumbEllipsisSize } from "./Breadcrumbs/BreadcrumbEllipsis/props";
 export type { IBreadcrumbLink } from "./Breadcrumbs/BreadcrumbLink";
-export type { IBreadcrumbLinkSizes } from "./Breadcrumbs/BreadcrumbLink/props";
-export type { IBreadcrumbs } from "./Breadcrumbs/index";
+export type { IBreadcrumbLinkSize } from "./Breadcrumbs/BreadcrumbLink/props";
 export type {
   IBreadcrumbsRoutes,
-  IBreadcrumbsIRoute,
-  IBreadcrumbsSizes,
+  IBreadcrumbsRoute,
+  IBreadcrumbsSize,
 } from "./Breadcrumbs/props";
 export type { IBreadcrumbMenu } from "./Breadcrumbs/BreadcrumbMenu";


### PR DESCRIPTION
The names of the interfaces used by the `<Breadcrumbs />` component were refactored, as well as how they are exported.