### PR TITLE
Refactor component (breadcrumbs) so it uses theme from ThemeContext

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,10 +40,10 @@
     "access": "public"
   },
   "dependencies": {
-    "@inubekit/foundations": "^2.7.0",
+    "@inubekit/foundations": "^2.12.1",
     "@inubekit/hooks": "^1.1.0",
-    "@inubekit/stack": "1.1.0",
-    "@inubekit/text": "^2.1.0"
+    "@inubekit/stack": "^2.1.1",
+    "@inubekit/text": "^2.2.1"
   },
   "peerDependencies": {
     "react": "^18.2.0",

--- a/src/Breadcrumbs/BreadcrumbEllipsis/index.tsx
+++ b/src/Breadcrumbs/BreadcrumbEllipsis/index.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useRef } from "react";
-
-import { Text } from "@inubekit/text";
+import { useContext } from "react";
+import { ThemeContext } from "styled-components";
+import { ITextAppearance, Text } from "@inubekit/text";
 import { BreadcrumbMenu } from "../BreadcrumbMenu";
-
+import { inube } from "@inubekit/foundations";
 import { IBreadcrumbsRoutes } from "../props";
 
 import { IBreadcrumbEllipsisSize } from "./props";
@@ -19,7 +20,7 @@ interface IBreadcrumbEllipsis extends IBreadcrumbsRoutes {
 const BreadcrumbEllipsis = (props: IBreadcrumbEllipsis) => {
   const { size = "large", routes } = props;
   const [showMenu, setShowMenu] = useState(false);
-
+  const theme: typeof inube = useContext(ThemeContext);
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   const closeEllipsisMenu = (event: globalThis.MouseEvent) => {
@@ -43,10 +44,18 @@ const BreadcrumbEllipsis = (props: IBreadcrumbEllipsis) => {
     setShowMenu(!showMenu);
   };
 
+  const textAppearance = (theme?.breadcrumbs?.content?.active ||
+    inube.breadcrumbs.content.active) as ITextAppearance;
+
   return (
     <StyledRelativeContainer ref={containerRef} onClick={toggleEllipsisMenu}>
       <StyledContainerEllipsis>
-        <Text type="label" size={size} appearance="dark" textAlign="start">
+        <Text
+          type="label"
+          size={size}
+          appearance={textAppearance}
+          textAlign="start"
+        >
           <StyledBreadcrumbEllipsis>...</StyledBreadcrumbEllipsis>
         </Text>
       </StyledContainerEllipsis>

--- a/src/Breadcrumbs/BreadcrumbLink/index.tsx
+++ b/src/Breadcrumbs/BreadcrumbLink/index.tsx
@@ -1,7 +1,9 @@
-import { Text } from "@inubekit/text";
+import { ITextAppearance, Text } from "@inubekit/text";
 import { inube } from "@inubekit/foundations";
 import { IBreadcrumbLinkSize } from "./props";
 import { StyledContainerLink, StyledBreadcrumbLink } from "./styles";
+import { useContext } from "react";
+import { ThemeContext } from "styled-components";
 
 interface IBreadcrumbLink {
   label: string;
@@ -14,6 +16,10 @@ interface IBreadcrumbLink {
 
 const BreadcrumbLink = (props: IBreadcrumbLink) => {
   const { label, path, id, size = "large", active = false, onClick } = props;
+  const theme: typeof inube = useContext(ThemeContext);
+
+  const activeTextAppearance = (theme?.breadcrumbs?.content?.active ||
+    inube.breadcrumbs.content.active) as ITextAppearance;
 
   const interceptOnClick = (e: React.MouseEvent) => {
     try {
@@ -33,11 +39,7 @@ const BreadcrumbLink = (props: IBreadcrumbLink) => {
         <Text
           type="label"
           size={size}
-          appearance={
-            active
-              ? (inube.breadcrumbs.content.active as keyof typeof inube.text)
-              : "gray"
-          }
+          appearance={active ? activeTextAppearance : "gray"}
           textAlign="start"
         >
           {label}


### PR DESCRIPTION
This pull request showcases a strategic enhancement of a specific UI component within our application, focusing on its integration with the application-wide theming system via ThemeContext. Aimed at bolstering visual consistency and streamlining the application of thematic elements, this refactor ensures that the component dynamically adapts to the theme settings defined within ThemeContext, promoting a cohesive user interface and improving maintainability.